### PR TITLE
Add Deploy Worker GPU target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,19 @@ else
 endif
 	@$(OPENSHIFT_INSTALLER) --log-level debug --dir clusters/$(CLUSTER_NAME) create cluster
 
+##@ DEPLOY GPU WORKER NODES
+.PHONY: deploy_worker_gpu
+deploy_worker_gpu: ## Create a new MachineSet for the GPU workers
+	$(info Creating a new MachineSet for the GPU workers)
+ifeq (,$(wildcard clusters/$(CLUSTER_NAME)/auth/kubeconfig))
+	$(error The kubeconfig is missing, it should be at clusters/$(CLUSTER_NAME)/auth/kubeconfig)
+endif
+ifeq (,$(shell which oc))
+	$(error oc command not found, please go to https://amd64.ocp.releases.ci.openshift.org/ and download the OpenShift Client)
+endif
+	@cd scripts && ./create_worker_gpu.sh $(CLUSTER_NAME)
+	@cd scripts && ./install_gpu_operators.sh $(CLUSTER_NAME)
+
 ##@ CLEAN SHIFTSTACK
 .PHONY: clean_shiftstack
 clean_shiftstack: ## Clean OpenShift on RHOSO cluster

--- a/scripts/create_worker_gpu.sh
+++ b/scripts/create_worker_gpu.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -ex
+
+CLUSTER_NAME=$1
+GPU_MACHINESET=new-gpu-machineset.yaml
+export KUBECONFIG=../clusters/${CLUSTER_NAME}/auth/kubeconfig
+
+# Checking the cluster health
+if ! oc get clusterversion version -o jsonpath='{range .status.conditions[*]}{.type}={.status} {end}' | grep -E -q 'Available=True.*Progressing=False|Progressing=False.*Available=True'; then
+  echo "Cluster is DEGRADED or UPDATING (Check 'oc get clusterversion')"
+  exit 1
+fi
+
+MACHINESET_NAME=$(oc get machinesets -n openshift-machine-api -l machine.openshift.io/cluster-api-machine-role=worker -o jsonpath='{.items[0].metadata.name}')
+oc get machinesets ${MACHINESET_NAME} -n openshift-machine-api -o yaml > ${GPU_MACHINESET}
+sed -i "s|${MACHINESET_NAME}|${MACHINESET_NAME%0}1|g" ${GPU_MACHINESET}
+sed -i "/flavor/ s/: .*/: worker_gpu/" ${GPU_MACHINESET}
+
+oc create -f ${GPU_MACHINESET}
+
+echo "Waiting for the worker gpu node to be ready"
+oc wait machinesets/${MACHINESET_NAME%0}1 -n openshift-machine-api --for=jsonpath='{.status.availableReplicas}'=1 --timeout=40m
+
+echo "Verifying that the GPU card is present on the worker"
+WORKER_GPU_NAME=$(oc get machine -n openshift-machine-api -l machine.openshift.io/cluster-api-machineset=${MACHINESET_NAME%0}1 -o jsonpath='{.items[0].metadata.name}')
+echo "Checking GPU on node: ${WORKER_GPU_NAME}"
+oc debug node/${WORKER_GPU_NAME} -- bash -c 'chroot /host lspci | grep NVIDIA' || { echo "The GPU card is not present on the ${WORKER_GPU_NAME} worker node"; exit 1; }

--- a/scripts/firewall_permissions.sh
+++ b/scripts/firewall_permissions.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x
+set -ex
 
 sudo firewall-cmd --zone=libvirt --add-service=http --permanent
 sudo firewall-cmd --zone=libvirt --add-service=https --permanent

--- a/scripts/install_gpu_operators.sh
+++ b/scripts/install_gpu_operators.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+
+set -ex
+
+CLUSTER_NAME=$1
+export KUBECONFIG=../clusters/${CLUSTER_NAME}/auth/kubeconfig
+
+# Checking the cluster health
+if ! oc get clusterversion version -o jsonpath='{range .status.conditions[*]}{.type}={.status} {end}' | grep -E -q 'Available=True.*Progressing=False|Progressing=False.*Available=True'; then
+  echo "Cluster is DEGRADED or UPDATING (Check 'oc get clusterversion')"
+  exit 1
+fi
+
+echo "Deploying the NFD Operator"
+
+oc create namespace openshift-nfd || true
+
+tee nfd-operatorgroup.yaml << EOF
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: nfd-operatorgroup
+  namespace: openshift-nfd
+spec:
+  targetNamespaces:
+  - openshift-nfd
+EOF
+
+oc apply -f nfd-operatorgroup.yaml
+
+tee nfd-subscription.yaml << EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: nfd-operator-subscription
+  namespace: openshift-nfd
+spec:
+  channel: "stable"
+  installPlanApproval: Automatic
+  name: nfd
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+
+oc apply -f nfd-subscription.yaml
+
+oc wait --for=condition=Available --timeout=5m deployment/nfd-controller-manager -n openshift-nfd
+
+tee nfd-instance.yaml << EOF
+apiVersion: nfd.openshift.io/v1
+kind: NodeFeatureDiscovery
+metadata:
+  name: nfd-instance
+  namespace: openshift-nfd
+spec: {}
+EOF
+
+oc apply -f nfd-instance.yaml
+
+sleep 10
+
+oc wait pod --all --for=condition=Ready -n openshift-nfd --timeout=5m
+
+oc rollout status daemonset/nfd-worker -n openshift-nfd --watch --timeout=5m
+
+echo "Deploying the NVIDIA Operator"
+
+oc create namespace nvidia-gpu-operator || true
+
+tee gpu-operator-group.yaml << EOF
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: nvidia-gpu-operator-group
+  namespace: nvidia-gpu-operator
+spec:
+  targetNamespaces:
+  - nvidia-gpu-operator
+EOF
+
+oc apply -f gpu-operator-group.yaml
+
+NVIDIA_CHANNEL=`oc get packagemanifest gpu-operator-certified -n openshift-marketplace -o jsonpath='{.status.defaultChannel}'`
+
+NVIDIA_STARTINGCSV=`oc get packagemanifest gpu-operator-certified -n openshift-marketplace -o jsonpath='{.status.channels[?(@.name=="'"${NVIDIA_CHANNEL}"'")].currentCSV}{"\n"}'`
+
+tee nvidia-gpu-operator.yaml << EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: gpu-operator-certified
+  namespace: nvidia-gpu-operator
+spec:
+  channel: ${NVIDIA_CHANNEL}
+  installPlanApproval: Automatic
+  name: gpu-operator-certified
+  source: certified-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: ${NVIDIA_STARTINGCSV}
+EOF
+
+oc apply -f nvidia-gpu-operator.yaml
+
+sleep 10
+
+echo "Waiting for GPU operator deployment to be available..."
+oc wait --for=condition=Available --timeout=5m deployment/gpu-operator -n nvidia-gpu-operator
+
+echo "Waiting for GPU operator CSV to be ready..."
+oc wait --for=jsonpath='{.status.phase}'=Succeeded --timeout=5m csv -l operators.coreos.com/gpu-operator-certified.nvidia-gpu-operator -n nvidia-gpu-operator
+
+tee gpu-clusterpolicy.yaml << EOF
+apiVersion: nvidia.com/v1
+kind: ClusterPolicy
+metadata:
+  name: gpu-cluster-policy
+spec:
+  daemonsets: {}
+  dcgm: {}
+  dcgmExporter: {}
+  devicePlugin: {}
+  driver: {}
+  gfd: {}
+  nodeStatusExporter: {}
+  operator: {}
+  toolkit: {}
+EOF
+
+oc apply -f gpu-clusterpolicy.yaml
+
+oc wait ClusterPolicy gpu-cluster-policy  -n nvidia-gpu-operator --for condition=Ready=True --timeout=30m
+
+echo "Verifying the GPU operator labelled the worker node"
+oc get node -l nvidia.com/gpu.present -oname
+
+echo "Creating a GPU operator verification job"
+
+tee verify-cuda-vectoradd.yaml << EOF
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-cuda-vectoradd
+  namespace: nvidia-gpu-operator
+spec:
+  completionMode: NonIndexed
+  template:
+    metadata:
+      labels:
+        app: cuda-vectoradd
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: cuda-vectoradd
+        image: "nvidia/samples:vectoradd-cuda11.2.1"
+        resources:
+          limits:
+            nvidia.com/gpu: 1
+EOF
+
+oc apply -f verify-cuda-vectoradd.yaml
+
+oc wait --for=condition=complete job/verify-cuda-vectoradd -n nvidia-gpu-operator --timeout=5m
+
+oc logs job/verify-cuda-vectoradd -n nvidia-gpu-operator

--- a/scripts/openstack_prerequisites.sh
+++ b/scripts/openstack_prerequisites.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
-set -x
+set -ex
 
 VCPU=$1
 RAM_MB=$((${2} * 1024))
 GIGABYTES=$3
+
+if ! which openstack > /dev/null 2>&1; then
+    echo "openstack command not found, installing python-openstackclient..."
+    sudo dnf -y install pip
+    pip install python-openstackclient
+fi
 
 echo "Getting the OpenStack Credentials"
 

--- a/scripts/proxy_setup.sh
+++ b/scripts/proxy_setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x
+set -ex
 
 PROXY_USER=$1
 PROXY_PASSWORD=$2
@@ -27,3 +27,5 @@ EOF
 sudo htpasswd -bBc /etc/squid/htpasswd $PROXY_USER $PROXY_PASSWORD
 
 sudo systemctl start squid
+
+sudo systemctl status squid --no-pager || exit 1


### PR DESCRIPTION
Deploy Worker GPU target is going to run the following:

- Create a new MachineSet for the GPU workers
- Verifying that the GPU card is present on the worker
- Deploy the GPU Operators
- Verify the GPU operator labelled the worker node
- Create a GPU operator verification job