### PR TITLE
Add Deploy RHOAI target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,18 @@ endif
 	@cd scripts && ./create_worker_gpu.sh $(CLUSTER_NAME)
 	@cd scripts && ./install_gpu_operators.sh $(CLUSTER_NAME)
 
+##@ DEPLOY OPENSHIFT AI
+.PHONY: deploy_rhoai
+deploy_rhoai: ## Deploy OpenShift AI
+	$(info Installing OpenShift AI Operators)
+ifeq (,$(wildcard clusters/$(CLUSTER_NAME)/auth/kubeconfig))
+	$(error The kubeconfig is missing, it should be at clusters/$(CLUSTER_NAME)/auth/kubeconfig)
+endif
+ifeq (,$(shell which oc))
+	$(error oc command not found, please go to https://amd64.ocp.releases.ci.openshift.org/ and download the OpenShift Client)
+endif
+	@cd scripts && ./install_rhoai_operators.sh $(CLUSTER_NAME)
+
 ##@ CLEAN SHIFTSTACK
 .PHONY: clean_shiftstack
 clean_shiftstack: ## Clean OpenShift on RHOSO cluster

--- a/scripts/install_rhoai_operators.sh
+++ b/scripts/install_rhoai_operators.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+
+set -ex
+
+CLUSTER_NAME=$1
+export KUBECONFIG=../clusters/${CLUSTER_NAME}/auth/kubeconfig
+
+# Checking the cluster health
+if ! oc get clusterversion version -o jsonpath='{range .status.conditions[*]}{.type}={.status} {end}' | grep -E -q 'Available=True.*Progressing=False|Progressing=False.*Available=True'; then
+  echo "Cluster is DEGRADED or UPDATING (Check 'oc get clusterversion')"
+  exit 1
+fi
+
+echo "Deploying the Servicemesh Operator"
+
+tee servicemesh-operator.yaml << EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: servicemeshoperator
+  namespace: openshift-operators
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: servicemeshoperator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+
+oc apply -f servicemesh-operator.yaml
+
+echo "Waiting for Servicemesh Operator to be ready..."
+sleep 10
+oc wait --for=condition=Available --timeout=5m deployment.apps/istio-operator -n openshift-operators
+
+echo "Deploying the Serverless Operator"
+
+oc create namespace openshift-serverless || true
+
+tee serverless-operator-group.yaml << EOF
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: serverless-operators
+  namespace: openshift-serverless
+spec: {}
+EOF
+
+oc apply -f serverless-operator-group.yaml
+
+tee serverless-operator.yaml << EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: serverless-operator
+  namespace: openshift-serverless
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: serverless-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+
+oc apply -f serverless-operator.yaml
+
+echo "Waiting for OpenShift Serverless Operator to be ready..."
+sleep 10
+oc wait --for=condition=Available --timeout=5m deployment/knative-openshift -n openshift-serverless
+
+echo "Deploying the Red Hat OpenShift AI Operator"
+
+oc create namespace redhat-ods-operator || true
+
+tee rhods-operator-group.yaml << EOF
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: redhat-operators
+  namespace: redhat-ods-operator
+EOF
+
+oc apply -f rhods-operator-group.yaml
+
+tee rhods-operator.yaml << EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: rhods-operator
+  namespace: redhat-ods-operator
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: rhods-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+
+oc apply -f rhods-operator.yaml
+
+echo "Waiting for RHOAI Operator to be ready..."
+sleep 10
+oc wait --for=condition=Available --timeout=10m deployment/rhods-operator -n redhat-ods-operator
+
+tee default-dsc.yaml << EOF
+apiVersion: datasciencecluster.opendatahub.io/v1
+kind: DataScienceCluster
+metadata:
+  name: default-dsc
+spec:
+  components:
+    codeflare:
+      managementState: Managed
+    dashboard:
+      managementState: Managed
+    datasciencepipelines:
+      managementState: Managed
+    feastoperator:
+      managementState: Removed
+    kserve:
+      managementState: Managed
+      nim:
+        managementState: Managed
+      rawDeploymentServiceConfig: Headless
+      serving:
+        ingressGateway:
+          certificate:
+            type: OpenshiftDefaultIngress
+        managementState: Managed
+        name: knative-serving
+    kueue:
+      managementState: Managed
+    llamastackoperator: {}
+    modelmeshserving:
+      managementState: Managed
+    modelregistry:
+      managementState: Removed
+      registriesNamespace: rhoai-model-registries
+    ray:
+      managementState: Managed
+    trainingoperator:
+      managementState: Managed
+    trustyai:
+      managementState: Managed
+    workbenches:
+      managementState: Managed
+      workbenchNamespace: rhods-notebooks
+EOF
+
+oc apply -f default-dsc.yaml
+
+echo "Waiting for DataScience Cluster to be ready..."
+sleep 10
+oc wait --timeout=10m DataScienceCluster default-dsc --for jsonpath='{.status.phase}'=Ready
+
+echo "Go to the RHOAI dashboard URL"
+oc get route -n redhat-ods-applications
+RHOAI_HOST=`oc get route -n redhat-ods-applications -o jsonpath='{.items[0].spec.host}'`
+RHOAI_PORT=`oc get route -n redhat-ods-applications -o jsonpath='{.items[0].spec.port.targetPort}'`
+echo "Access the RHOAI dashboard https://${RHOAI_HOST}:${RHOAI_PORT}"


### PR DESCRIPTION
Add Deploy RHOAI target is going to install the following resources:

- Servicemesh Operator
- Serverless Operator
- Red Hat OpenShift AI Operator
- DataScience Cluster

Finally, it shows the RHOAI dashboard URL