### PR TITLE
Upgrade EDPM default compute resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 PULL_SECRET ?= ~/pull-secret
 SSH_PUB_KEY ?= ~/.ssh/id_rsa.pub
 
-EDPM_CPUS ?= 36
-EDPM_RAM ?= 144
+EDPM_CPUS ?= 40
+EDPM_RAM ?= 160
 EDPM_DISK ?= 640
 
 PROXY_USER ?= rhoai


### PR DESCRIPTION
**What does this PR do?**
Upgrade the default EDPM CPU and RAM values

**Why do we need it?**
For ShiftStack deployment, it is necessary to have 3 masters, 1 bootstrap, and at least 1 worker. Masters and the bootstrap share the same flavor; the worker must accomplish the [minimum requirements](https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/2.8/html/installing_and_uninstalling_openshift_ai_self-managed/installing-and-deploying-openshift-ai_install)  for supporting the OpenShift AI Operators. Besides, the worker GPU must accomplish the minimum requirement plus additional cluster resources to ensure that OpenShift AI is usable and supports the accelerated data plane components. Therefore, these are the minimum requirements for deploying RHOAI on RHOSO for development and test purposes. 

<b style="font-weight:normal;" id="docs-internal-guid-a3f90021-7fff-d9b4-408b-558d359f25ef"><div dir="ltr" style="margin-left:0pt;" align="left">
NODE | COUNT | FLAVOR | CPU | RAM
-- | -- | -- | -- | --
master | 3 | master | 12 | 48
boostrap | 1 | master | 4 | 16
worker | 1 | worker | 8 | 32
worker GPU | 1 | worker_gpu | 16 | 64
TOTAL | | | 40 | 160
</div></b>

> [!NOTE] 
> The Red Hat OpenShift AI (RHOAI) Operators will deploy their management components (controllers, dashboard, core services) on both workers, but they will only deploy the accelerated data plane components (like the NVIDIA stack) on the node with the GPU.