### PR TITLE
Update sleep up to 2m before check the nfd-controller-manager status

### DIFF
--- a/scripts/install_gpu_operators.sh
+++ b/scripts/install_gpu_operators.sh
@@ -42,7 +42,7 @@ spec:
 EOF
 
 echo "Waiting for NFD deployment to be available..."
-sleep 30
+sleep 120
 ${OPENSHIFT_CLIENT} wait --for=condition=Available --timeout=5m deployment/nfd-controller-manager -n openshift-nfd
 
 cat << EOF | ${OPENSHIFT_CLIENT} apply -f -


### PR DESCRIPTION
The nfd-controller-manager deployment in the openshift-nfd namespace needs a least 2 minutes before the cluster starts to list it as a resource. Otherwise, it will fail with the message `Error from server (NotFound): deployments.apps "nfd-controller-manager" not found`
